### PR TITLE
Use async functions in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "ava": "0.11.0",
     "babel-cli": "6.5.1",
+    "babel-eslint": "4.1.8",
     "babel-preset-es2015-node4": "2.0.3",
     "babel-register": "6.5.1",
     "coveralls": "2.11.6",
@@ -65,5 +66,8 @@
     "presets": [
       "es2015-node4"
     ]
+  },
+  "standard": {
+    "parser": "babel-eslint"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,12 +3,11 @@ import test from 'ava'
 
 import promisify from './src'
 
-test('promisify calls wrapped function with arguments', (t) => {
+test('promisify calls wrapped function with arguments', async function (t) {
   const fn = sinon.stub().yields()
   const promisified = promisify(fn)
-  return promisified('some', 'arguments').then(() => {
-    t.true(fn.calledWith('some', 'arguments'))
-  })
+  await promisified('some', 'arguments')
+  t.true(fn.calledWith('some', 'arguments'))
 })
 
 test('promisify rejects when wrapped function returns error', (t) => {
@@ -24,20 +23,18 @@ test('promisify resolves when wrapped function returns no error', (t) => {
   return t.doesNotThrow(promisified('some', 'arguments'))
 })
 
-test('promisify resolves single value as such', (t) => {
+test('promisify resolves single value as such', async function (t) {
   const fn = sinon.stub().yields(null, 42)
   const promisified = promisify(fn)
-  return promisified('some', 'arguments').then((result) => {
-    t.is(result, 42)
-  })
+  const result = await promisified('some', 'arguments')
+  t.is(result, 42)
 })
 
-test('promisify resolves multiple value as an array', (t) => {
+test('promisify resolves multiple value as an array', async function (t) {
   const fn = sinon.stub().yields(null, 'a', 'result')
   const promisified = promisify(fn)
-  return promisified('some', 'arguments').then((result) => {
-    t.same(result, ['a', 'result'])
-  })
+  const result = await promisified('some', 'arguments')
+  t.same(result, ['a', 'result'])
 })
 
 test('promisify throws when no function is passed', (t) => {


### PR DESCRIPTION
ava uses the stage2 preset for the testing code. Hence, async/await can be used.
